### PR TITLE
Fix getCurrentMicros function.

### DIFF
--- a/cores/arduino/ch32/clock.c
+++ b/cores/arduino/ch32/clock.c
@@ -57,13 +57,13 @@ uint32_t getCurrentMicros(void)
   uint64_t m0 = GetTick();
   __IO uint64_t u0 = SysTick->CNT;
   uint64_t m1 = GetTick();
-  __IO uint32_t u1 = SysTick->CNT;   //may be a interruption
+  __IO uint64_t u1 = SysTick->CNT;   //may be a interruption
    uint64_t tms = SysTick->CMP + 1;
 
   if (m1 != m0) {
-    return (m1 * 1000 + ((tms - u1) * 1000) / tms);
+    return (m1 * 1000 + (u1 * 1000) / tms);
   } else {
-    return (m0 * 1000 + ((tms - u0) * 1000) / tms);
+    return (m0 * 1000 + (u0 * 1000) / tms);
   }
 }
 


### PR DESCRIPTION
Fix the getCurrentMicros() function. The current implementation is incorrect since SysTick is counting up. 